### PR TITLE
:sparkles: Add activate service account + project id in app.json

### DIFF
--- a/commands/get.js
+++ b/commands/get.js
@@ -84,7 +84,7 @@ vorpal
                 type: args.platform || Helper.Project.getPlatform(args.platform),
                 target: args.options.target || Helper.TARGET_ALL,
                 skillId: args.options['skill-id'] || Helper.Project.getConfigParameter('alexaSkill.skillId', args.options.stage) || config.skillId,
-                projectId: args.options['project-id'],
+                projectId: args.options['project-id'] || Helper.Project.getConfigParameter('googleAction.dialogflow.projectId', args.options.stage),
                 stage: args.options.stage,
                 askProfile: args.options['ask-profile'] || Helper.Project.getConfigParameter('alexaSkill.ask-profile', args.options.stage) || Helper.DEFAULT_ASK_PROFILE,
             });

--- a/commands/run.js
+++ b/commands/run.js
@@ -160,6 +160,10 @@ function jovoWebhook(port, stage) {
     socket.on('connect', function() {
         console.log('This is your webhook url: ' + Helper.JOVO_WEBHOOK_URL + '/' + user);
     });
+    socket.on('connect_error', function(error) {
+        console.log('Sorry, there seems to be an issue with the connection!');
+        console.log(error);
+    });
     socket.on('request-'+user, (data) => {
         post(data.request, port).then((result) => {
             socket.emit('response-' + user, result);

--- a/helper/alexaUtil.js
+++ b/helper/alexaUtil.js
@@ -410,7 +410,7 @@ module.exports = {
             info.name += locales[locale].name + ' (' +locale+ ') ';
         }
         info.skillId = this.getSkillId();
-        info.endpoint = skillJson.manifest.apis.custom.endpoint.uri;
+        info.endpoint = _.get(skillJson, 'manifest.apis.custom.endpoint.uri', '');
         return info;
     },
 
@@ -712,7 +712,7 @@ module.exports.Ask = {
                     if (stderr && stderr.indexOf('AccountLinking is not present for given skillId') > 0) {
                         resolve();
                     } else if (stderr) {
-                        return reject(self.getAskError(stderr));
+                        return reject(self.getAskError('askApiGetAccountLinking', stderr));
                     }
                 }
                 resolve(stdout);
@@ -730,9 +730,9 @@ module.exports.Ask = {
         return new Promise((resolve, reject) => {
             exec('ask lambda upload -f ' + config.lambdaArn + ' -s "' + config.src + '"', {
             }, function(error, stdout, stderr ) {
-                if (error) {
+                if (error || stderr) {
                     if (stderr) {
-                        return reject(self.getAskError(stderr));
+                        return reject(self.getAskError('askLambdaUpload', stderr));
                     }
                 }
                 console.log(stdout);

--- a/helper/dialogflowUtil.js
+++ b/helper/dialogflowUtil.js
@@ -297,6 +297,27 @@ module.exports = {
 
 
         /**
+         * Activate gcloud service account
+         * @param {*} config
+         * @return {Promise<any>}
+         */
+        activateServiceAccount: function(config) {
+            return new Promise((resolve, reject) => {
+                try {
+                    exec('gcloud auth activate-service-account --key-file=' + config.keyFile, function(error, stdout, stderr ) {
+                        if (error) {
+                            if (stderr || error) {
+                                return reject(new Error('Could not activate your service account: ' + stderr));
+                            }
+                        }
+                        resolve();
+                    });
+                } catch (error) {
+                    console.log(error);
+                }
+            });
+        },
+        /**
          * Retrieves access token from gcloud cli
          * @return {Promise<any>}
          */

--- a/helper/lmHelper.js
+++ b/helper/lmHelper.js
@@ -453,7 +453,6 @@ module.exports.Project = {
                         googleAction: {
                             nlu: {
                                 name: 'dialogflow',
-                                version: 1,
                             },
                         },
                     });


### PR DESCRIPTION
- Added `gcloud auth activate-service-account' functionality to staging
- Added GoogleAction/Dialogflow project-id to staging

Example app.json: 
```
{
	"endpoint": "<ENDPOINT_URL>",
	"googleAction": {
		"nlu": {
			"name": "dialogflow"
		},
		"dialogflow": {
			"projectId": "<PROJECT_ID>",
			"keyFile": "<KEY_FILE_NAME>.json"
		}
	}
}
```