### PR TITLE
:bug: always emit a response

### DIFF
--- a/commands/run.js
+++ b/commands/run.js
@@ -175,10 +175,9 @@ function jovoWebhook(port, stage) {
         post(data.request, port).then((result) => {
             socket.emit('response-' + user, result);
         }).catch((error) => {
-            console.log();
-            console.log(error.message);
-            console.log();
-            console.log(error);
+            console.log('Local server did not return a valid JSON response:');
+            console.log(error.rawData);
+            socket.emit('response-' + user, null);
         });
     });
 }
@@ -212,12 +211,11 @@ function post(requestObj, port) {
                 let parsedData;
                 try {
                     parsedData = JSON.parse(rawData);
+                    resolve(parsedData);
                 } catch (e) {
-                    reject(new Error('Something went wrong'));
-                    return;
+                    e.rawData = rawData;
+                    reject(e);
                 }
-
-                resolve(parsedData);
             });
         }).on('error', (e) => {
             if (e.code === 'ECONNRESET') {


### PR DESCRIPTION
When the local server does not return a valid JSON body, the request times out since no response is sent back to the Jovo Webhook. The logged stack trace is not very helpful as it always just says: "Something went wrong".

With this change the invalid response body is logged instead and an event with a null response is emitted via the socket connection to trigger an immediate output.