### PR TITLE
Support JS as model files

### DIFF
--- a/helper/lmHelper.js
+++ b/helper/lmHelper.js
@@ -137,16 +137,8 @@ module.exports.Project = {
             if (files.length === 0) {
                 return [DEFAULT_LOCALE];
             }
-            let locales = [];
-            for (let file of files) {
-                if (file.length === 10) {
-                    locales.push(file.substr(0, 5));
-                }
-                if (file.length === 7) {
-                    locales.push(file.substr(0, 2));
-                }
-            }
-            return locales;
+
+            return files.map((file) => path.parse(file).name);
         } catch (err) {
             throw err;
         }
@@ -263,7 +255,13 @@ module.exports.Project = {
                 fs.mkdirSync(this.getModelsPath());
             }
 
-            fs.writeFile(this.getModelPath(locale), JSON.stringify(model, null, '\t'), function(err) {
+            const modelPath = this.getModelPath(locale) + '.json';
+
+            if (!fs.existsSync(modelPath)) {
+                console.log('Warning: Model file not found, if you changed it to a JS file is not possible to change this model anymore. If you want to, please turn it back to a JSON file. Saving into ' + locale + '.json.');
+            }
+
+            fs.writeFile(modelPath, JSON.stringify(model, null, '\t'), function(err) {
                 if (err) {
                     reject(err);
                     return;
@@ -301,7 +299,7 @@ module.exports.Project = {
      */
     getModelPath: function(locale) {
         // /models/{locale}.json
-        return this.getModelsPath() + path.sep + locale + '.json';
+        return path.join(this.getModelsPath(), locale);
     },
 
     /**


### PR DESCRIPTION
## Proposed changes

When you grow your application to more and more features, the model files inside the `models` directory get larger and complicated. The solution would split some parts of the file in smaller parts, but this CLI only supports JSON files and not JS files. Reading the code I realized that the model file name resolution was restricted to JSON files.

So I made a few changes to keep working with JSON files but also support JS files. I think this behavior could lead to a problem when the `saveModel` method would be called, so I add a warning when it happens.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed