### PR TITLE
Fix for issue #67, Dialogflow deploys creating empty zip file

### DIFF
--- a/helper/dialogflowUtil.js
+++ b/helper/dialogflowUtil.js
@@ -247,7 +247,9 @@ module.exports = {
                 zlib: {level: 9}, // Sets the compression level.
             });
 
+            // listen for all archive data to be written, resolving promise once that occurs
             output.on('close', function() {
+                resolve(zipPath);
             });
 
             output.on('end', function() {
@@ -275,8 +277,9 @@ module.exports = {
             if (fs.existsSync(this.getEntitiesFolderPath())) {
                 archive.directory(this.getEntitiesFolderPath(), 'entities');
             }
+
+            // signal that we are done appending files and the final output can be written
             archive.finalize();
-            resolve(zipPath);
         });
     },
 

--- a/test/testDeploy.js
+++ b/test/testDeploy.js
@@ -109,12 +109,14 @@ describe('deploy', function() {
                 }, (errorDeploy, stdoutDeploy, stderrDeploy) => {
                     expect(stdoutDeploy).to.contain('Deployment completed.');
 
-                    expect(
-                        fs.existsSync(
-                            projectFolder + path.sep +
+                    const dialogflowAgentZipPath = projectFolder + path.sep +
                             'platforms' + path.sep +
                             'googleAction' + path.sep +
-                            'dialogflow_agent.zip')).to.equal(true);
+                        'dialogflow_agent.zip';
+
+                    expect(fs.existsSync(dialogflowAgentZipPath), 'Dialogflow agent zip should exist').to.equal(true);
+                    expect(fs.statSync(dialogflowAgentZipPath).size, 'Dialogflow agent zip should not be empty').to.not.equal(0);
+
                     done();
                 });
             }


### PR DESCRIPTION
## Proposed changes
This addresses issue #67, where Dialogflow deploys where creating an empty agent zip file. This was a regression caused by PR #64, which made the program terminate quicker and exposed the fact that a promise was being signaled before the zip file was fully written. 

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed