### PR TITLE
Removing unneeded jsonlint dependency

### DIFF
--- a/jovo-cli/commands/tasks.ts
+++ b/jovo-cli/commands/tasks.ts
@@ -15,7 +15,6 @@ import {
 	JovoCliPlatform,
 } from 'jovo-cli-core';
 import * as DeployTargets from '../utils/DeployTargets';
-const jsonlint = require("jsonlint");
 
 const { promisify } = require('util');
 const existsAsync = promisify(fs.exists);
@@ -140,19 +139,14 @@ export function buildTask(ctx: JovoTaskContext) {
 							return task.skip('Model file is JavaScript not JSON so check got skipped.');
 						}
 
-						return Promise.reject(new Error(`Language model file could not be found. Expected location: "${error.path}"`));
+						throw new Error(`Language model file could not be found. Expected location: "${error.path}"`);
 					}
 
 					throw (error);
 				}
 
-				try {
-					jsonlint.parse(modelFileContent);
-				} catch (error) {
-					return Promise.reject(new Error(error.message));
-				}
-
-				return Promise.resolve();
+				// ensure the model JSON is valid -- this will throw if it isn't
+				JSON.parse(modelFileContent);
 			}
 		});
 	});

--- a/jovo-cli/package-lock.json
+++ b/jovo-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jovo-cli",
-  "version": "1.2.3",
+  "version": "2.0.2-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -297,11 +297,6 @@
       "integrity": "sha512-gsPnt1APkEBk0kLYJYa5HFWblVOhj43L4krLVN+vNmVIjVLWiXa9N1JmsErcRbRmBjzsJbKpSM6dXsEHG/YZ/w==",
       "dev": true
     },
-    "JSV": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
-      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c="
-    },
     "abab": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
@@ -369,6 +364,24 @@
       "integrity": "sha512-ugTb7Lq7u4GfWSqqpwE0bGyoBZNMTok/zDBXxfEG0QM50jNlGhIWjRC1pPN7bvV1anhF+bs+/gNcRw+o55Evbg==",
       "dev": true
     },
+    "adm-zip": {
+      "version": "0.4.13",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/adm-zip/-/adm-zip-0.4.13.tgz",
+      "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw=="
+    },
+    "after": {
+      "version": "0.8.2",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/after/-/after-0.8.2.tgz",
+      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
+    },
+    "agent-base": {
+      "version": "4.2.1",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
+    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -435,6 +448,46 @@
         "default-require-extensions": "^1.0.0"
       }
     },
+    "archiver": {
+      "version": "3.0.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/archiver/-/archiver-3.0.0.tgz",
+      "integrity": "sha512-5QeR6Xc5hSA9X1rbQfcuQ6VZuUXOaEdB65Dhmk9duuRJHYif/ZyJfuyJqsQrj34PFjU5emv5/MmfgA8un06onw==",
+      "requires": {
+        "archiver-utils": "^2.0.0",
+        "async": "^2.0.0",
+        "buffer-crc32": "^0.2.1",
+        "glob": "^7.0.0",
+        "readable-stream": "^2.0.0",
+        "tar-stream": "^1.5.0",
+        "zip-stream": "^2.0.1"
+      }
+    },
+    "archiver-utils": {
+      "version": "2.0.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/archiver-utils/-/archiver-utils-2.0.0.tgz",
+      "integrity": "sha512-JRBgcVvDX4Mwu2RBF8bBaHcQCSxab7afsxAPYDQ5W+19quIPP5CfKE7Ql+UHs9wYvwsaNR8oDuhtf5iqrKmzww==",
+      "requires": {
+        "glob": "^7.0.0",
+        "graceful-fs": "^4.1.0",
+        "lazystream": "^1.0.0",
+        "lodash.assign": "^4.2.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.toarray": "^4.4.0",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+        }
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -495,6 +548,11 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
+    "arraybuffer.slice": {
+      "version": "0.0.7",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
+    },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -519,6 +577,11 @@
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
+    "ast-types": {
+      "version": "0.11.7",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/ast-types/-/ast-types-0.11.7.tgz",
+      "integrity": "sha512-2mP3TwtkY/aTv5X3ZsMpNAbOnyoC/aMJwJSoaELPkHId0nSQgFcnU4dRW3isxiz7+zBexk0ym3WNVjMiQBnJSw=="
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -541,8 +604,7 @@
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
-      "dev": true
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
     "async-listener": {
       "version": "0.6.9",
@@ -872,6 +934,11 @@
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -927,6 +994,11 @@
         }
       }
     },
+    "base64-arraybuffer": {
+      "version": "0.1.5",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+    },
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
@@ -972,10 +1044,32 @@
         }
       }
     },
+    "better-assert": {
+      "version": "1.0.2",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/better-assert/-/better-assert-1.0.2.tgz",
+      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+      "requires": {
+        "callsite": "1.0.0"
+      }
+    },
     "binary-extensions": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
       "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg=="
+    },
+    "bl": {
+      "version": "1.2.2",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/bl/-/bl-1.2.2.tgz",
+      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "blob": {
+      "version": "0.0.5",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/blob/-/blob-0.0.5.tgz",
+      "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
     },
     "body-parser": {
       "version": "1.18.3",
@@ -1092,6 +1186,39 @@
         "node-int64": "^0.4.0"
       }
     },
+    "buffer": {
+      "version": "5.2.1",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/buffer/-/buffer-5.2.1.tgz",
+      "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -1132,6 +1259,11 @@
       "requires": {
         "callsites": "^0.2.0"
       }
+    },
+    "callsite": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
     },
     "callsites": {
       "version": "0.2.0",
@@ -1354,10 +1486,31 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.18.0.tgz",
       "integrity": "sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ=="
     },
+    "component-bind": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/component-bind/-/component-bind-1.0.0.tgz",
+      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
+    },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+    },
+    "component-inherit": {
+      "version": "0.0.3",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/component-inherit/-/component-inherit-0.0.3.tgz",
+      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
+    },
+    "compress-commons": {
+      "version": "1.2.2",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/compress-commons/-/compress-commons-1.2.2.tgz",
+      "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+      "requires": {
+        "buffer-crc32": "^0.2.1",
+        "crc32-stream": "^2.0.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1476,6 +1629,23 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "crc": {
+      "version": "3.8.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "requires": {
+        "buffer": "^5.1.0"
+      }
+    },
+    "crc32-stream": {
+      "version": "2.0.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/crc32-stream/-/crc32-stream-2.0.0.tgz",
+      "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+      "requires": {
+        "crc": "^3.4.4",
+        "readable-stream": "^2.0.0"
+      }
+    },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
@@ -1544,6 +1714,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "data-uri-to-buffer": {
+      "version": "1.2.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
+      "integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ=="
+    },
     "data-urls": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.1.tgz",
@@ -1608,8 +1783,7 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "default-require-extensions": {
       "version": "1.0.0",
@@ -1663,6 +1837,23 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
+        }
+      }
+    },
+    "degenerator": {
+      "version": "1.0.4",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/degenerator/-/degenerator-1.0.4.tgz",
+      "integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
+      "requires": {
+        "ast-types": "0.x.x",
+        "escodegen": "1.x.x",
+        "esprima": "3.x.x"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
         }
       }
     },
@@ -1786,6 +1977,62 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "engine.io-client": {
+      "version": "3.3.1",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/engine.io-client/-/engine.io-client-3.3.1.tgz",
+      "integrity": "sha512-q66JBFuQcy7CSlfAz9L3jH+v7DTT3i6ZEadYcVj2pOs8/0uJHLxKX3WBkGTvULJMdz0tUCyJag0aKT/dpXL9BQ==",
+      "requires": {
+        "component-emitter": "1.2.1",
+        "component-inherit": "0.0.3",
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.1",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "ws": "~6.1.0",
+        "xmlhttprequest-ssl": "~1.5.4",
+        "yeast": "0.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ws": {
+          "version": "6.1.2",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/ws/-/ws-6.1.2.tgz",
+          "integrity": "sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "2.1.3",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
+      "integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
+      "requires": {
+        "after": "0.8.2",
+        "arraybuffer.slice": "~0.0.7",
+        "base64-arraybuffer": "0.1.5",
+        "blob": "0.0.5",
+        "has-binary2": "~1.0.2"
+      }
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -1857,8 +2104,15 @@
     "es6-promise": {
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
-      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
-      "dev": true
+      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
     },
     "es6-set": {
       "version": "0.1.5",
@@ -1909,7 +2163,6 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
       "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
-      "dev": true,
       "requires": {
         "esprima": "^3.1.3",
         "estraverse": "^4.2.0",
@@ -1921,14 +2174,12 @@
         "esprima": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
           "optional": true
         }
       }
@@ -2170,14 +2421,12 @@
     "estraverse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-      "dev": true
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
     },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
       "version": "1.8.1",
@@ -2556,8 +2805,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fb-watchman": {
       "version": "2.0.0",
@@ -2585,6 +2833,11 @@
         "flat-cache": "^1.2.1",
         "object-assign": "^4.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -2727,11 +2980,15 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.2.4",
@@ -3195,6 +3452,38 @@
         }
       }
     },
+    "ftp": {
+      "version": "0.3.10",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/ftp/-/ftp-0.3.10.tgz",
+      "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
+      "requires": {
+        "readable-stream": "1.1.x",
+        "xregexp": "2.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -3235,6 +3524,19 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
+    "get-uri": {
+      "version": "2.0.2",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/get-uri/-/get-uri-2.0.2.tgz",
+      "integrity": "sha512-ZD325dMZOgerGqF/rF6vZXyFGTAay62svjQIT+X/oU2PtxYpFxvSkbsdi+oxIrsNxlZVd4y8wUDqkaExWTI/Cw==",
+      "requires": {
+        "data-uri-to-buffer": "1",
+        "debug": "2",
+        "extend": "3",
+        "file-uri-to-path": "1",
+        "ftp": "~0.3.10",
+        "readable-stream": "2"
+      }
+    },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -3252,7 +3554,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3425,10 +3726,25 @@
         "ansi-regex": "^2.0.0"
       }
     },
-    "has-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
+    "has-binary2": {
+      "version": "1.0.3",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/has-binary2/-/has-binary2-1.0.3.tgz",
+      "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
+      "requires": {
+        "isarray": "2.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.1",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/isarray/-/isarray-2.0.1.tgz",
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+        }
+      }
+    },
+    "has-cors": {
+      "version": "1.1.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/has-cors/-/has-cors-1.1.0.tgz",
+      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
     },
     "has-flag": {
       "version": "3.0.0",
@@ -3505,6 +3821,25 @@
         "statuses": ">= 1.4.0 < 2"
       }
     },
+    "http-proxy-agent": {
+      "version": "2.1.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+      "requires": {
+        "agent-base": "4",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -3515,6 +3850,30 @@
         "sshpk": "^1.7.0"
       }
     },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
@@ -3522,6 +3881,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.1.12",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/ieee754/-/ieee754-1.1.12.tgz",
+      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
     },
     "ignore": {
       "version": "3.3.10",
@@ -3564,11 +3928,15 @@
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
       "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
     },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3639,6 +4007,11 @@
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ipaddr.js": {
       "version": "1.8.0",
@@ -5071,6 +5444,144 @@
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
+    "jovo-cli-core": {
+      "version": "2.0.2",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/jovo-cli-core/-/jovo-cli-core-2.0.2.tgz",
+      "integrity": "sha512-wbXGurjfHV3zlvenbSuktMHenIQCHSq9CHnphQfeiXxQl0esyxleKuJB28aBKNAhRZiwWvhhezchj0CSVwrc6g==",
+      "requires": {
+        "adm-zip": "^0.4.11",
+        "archiver": "^3.0.0",
+        "listr": "^0.14.2",
+        "uuid": "^3.2.1"
+      }
+    },
+    "jovo-cli-deploy-lambda": {
+      "version": "2.0.2",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/jovo-cli-deploy-lambda/-/jovo-cli-deploy-lambda-2.0.2.tgz",
+      "integrity": "sha512-vhfphosT39uMgrV2pqOxncvmDPO6PDLDuhe5AXdZfkLLfKrdRSL4prhCosojGeeYqbkXS+sPdwpAMbzze9xTGA==",
+      "requires": {
+        "aws-sdk": "^2.344.0",
+        "jovo-cli-core": "^2.0.2",
+        "listr": "^0.14.2",
+        "lodash": "^4.17.11",
+        "proxy-agent": "^3.0.3"
+      },
+      "dependencies": {
+        "aws-sdk": {
+          "version": "2.380.0",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/aws-sdk/-/aws-sdk-2.380.0.tgz",
+          "integrity": "sha512-V0en7O9cCOY4Vb99SFzT51YQ0gn3MhWK2T7SzRGKMjETQo4/PVlflEaBIkaJJlhDXrVzgZ+Fmft/tHEetTk44w==",
+          "requires": {
+            "buffer": "4.9.1",
+            "events": "1.1.1",
+            "ieee754": "1.1.8",
+            "jmespath": "0.15.0",
+            "querystring": "0.2.0",
+            "sax": "1.2.1",
+            "url": "0.10.3",
+            "uuid": "3.1.0",
+            "xml2js": "0.4.19"
+          }
+        },
+        "buffer": {
+          "version": "4.9.1",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/buffer/-/buffer-4.9.1.tgz",
+          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "ieee754": {
+          "version": "1.1.8",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/ieee754/-/ieee754-1.1.8.tgz",
+          "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+        }
+      }
+    },
+    "jovo-cli-platform-alexa": {
+      "version": "2.0.2",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/jovo-cli-platform-alexa/-/jovo-cli-platform-alexa-2.0.2.tgz",
+      "integrity": "sha512-ulmlk/ybjAnCqYmKn0UnxiTpLcvmfP8+oxMXcUHUgFg5FYD/8ebUegu+B53oztOkHVstN4f9eXy5XCvCiKmo8Q==",
+      "requires": {
+        "aws-sdk": "^2.344.0",
+        "chalk": "^2.4.1",
+        "jovo-cli-core": "^2.0.2",
+        "listr": "^0.14.2",
+        "lodash": "^4.17.11",
+        "vorpal": "^1.12.0"
+      },
+      "dependencies": {
+        "aws-sdk": {
+          "version": "2.380.0",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/aws-sdk/-/aws-sdk-2.380.0.tgz",
+          "integrity": "sha512-V0en7O9cCOY4Vb99SFzT51YQ0gn3MhWK2T7SzRGKMjETQo4/PVlflEaBIkaJJlhDXrVzgZ+Fmft/tHEetTk44w==",
+          "requires": {
+            "buffer": "4.9.1",
+            "events": "1.1.1",
+            "ieee754": "1.1.8",
+            "jmespath": "0.15.0",
+            "querystring": "0.2.0",
+            "sax": "1.2.1",
+            "url": "0.10.3",
+            "uuid": "3.1.0",
+            "xml2js": "0.4.19"
+          }
+        },
+        "buffer": {
+          "version": "4.9.1",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/buffer/-/buffer-4.9.1.tgz",
+          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "ieee754": {
+          "version": "1.1.8",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/ieee754/-/ieee754-1.1.8.tgz",
+          "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+        }
+      }
+    },
+    "jovo-cli-platform-google": {
+      "version": "2.0.2",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/jovo-cli-platform-google/-/jovo-cli-platform-google-2.0.2.tgz",
+      "integrity": "sha512-EIVEIz3cAO8H67kyUaJShrFhnIFIKHDFNOWWhTeEqFcvP9+dQ/Y/Me4HjeW+vHvoZyMHlNlpWhmC3/0n1oFQag==",
+      "requires": {
+        "adm-zip": "^0.4.11",
+        "archiver": "^3.0.0",
+        "chalk": "^2.4.1",
+        "jovo-cli-core": "^2.0.2",
+        "listr": "^0.14.2",
+        "lodash": "^4.17.11",
+        "request": "^2.88.0",
+        "vorpal": "^1.12.0"
+      }
+    },
+    "jovo-webhook-connector": {
+      "version": "2.0.2",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/jovo-webhook-connector/-/jovo-webhook-connector-2.0.2.tgz",
+      "integrity": "sha512-vnNBDR83pzZ4l+7feqAENTRDTU+8XqIIKVHqkocmFE6ClKbA2EdkRX+rqeav8Z5NwvK31q6bRRukZdPfDOHlcA==",
+      "requires": {
+        "lodash.merge": "^4.6.1",
+        "querystring": "^0.2.0",
+        "request": "^2.88.0",
+        "socket.io-client": "^2.1.1"
+      }
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -5177,15 +5688,6 @@
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
-    "jsonlint": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.3.tgz",
-      "integrity": "sha512-jMVTMzP+7gU/IyC6hvKyWpUU8tmTkK5b3BPNuMI9U8Sit+YAWLlZwB6Y6YrdCxfg2kNz05p3XY3Bmm4m26Nv3A==",
-      "requires": {
-        "JSV": "^4.0.x",
-        "nomnom": "^1.5.x"
-      }
-    },
     "jsonpointer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
@@ -5230,6 +5732,14 @@
         "package-json": "^4.0.0"
       }
     },
+    "lazystream": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/lazystream/-/lazystream-1.0.0.tgz",
+      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+      "requires": {
+        "readable-stream": "^2.0.5"
+      }
+    },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
@@ -5255,7 +5765,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -5461,16 +5970,56 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
     },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
+    },
+    "lodash.toarray": {
+      "version": "4.4.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
+    },
+    "lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
     },
     "log-symbols": {
       "version": "1.0.2",
@@ -5813,6 +6362,11 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
+    "netmask": {
+      "version": "1.0.6",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/netmask/-/netmask-1.0.6.tgz",
+      "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
+    },
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
@@ -5882,37 +6436,6 @@
         }
       }
     },
-    "nomnom": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-      "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
-      "requires": {
-        "chalk": "~0.4.0",
-        "underscore": "~1.6.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
-        },
-        "chalk": {
-          "version": "0.4.0",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-          "requires": {
-            "ansi-styles": "~1.0.0",
-            "has-color": "~0.1.0",
-            "strip-ansi": "~0.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "0.1.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
-        }
-      }
-    },
     "nopt": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
@@ -5968,6 +6491,11 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-component": {
+      "version": "0.0.3",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/object-component/-/object-component-0.0.3.tgz",
+      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -6091,7 +6619,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.4",
@@ -6157,6 +6684,48 @@
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
+    "pac-proxy-agent": {
+      "version": "3.0.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/pac-proxy-agent/-/pac-proxy-agent-3.0.0.tgz",
+      "integrity": "sha512-AOUX9jES/EkQX2zRz0AW7lSx9jD//hQS8wFXBvcnd/J2Py9KaMJMqV/LPqJssj1tgGufotb2mmopGPR15ODv1Q==",
+      "requires": {
+        "agent-base": "^4.2.0",
+        "debug": "^3.1.0",
+        "get-uri": "^2.0.0",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.1",
+        "pac-resolver": "^3.0.0",
+        "raw-body": "^2.2.0",
+        "socks-proxy-agent": "^4.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
+    "pac-resolver": {
+      "version": "3.0.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/pac-resolver/-/pac-resolver-3.0.0.tgz",
+      "integrity": "sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==",
+      "requires": {
+        "co": "^4.6.0",
+        "degenerator": "^1.0.4",
+        "ip": "^1.1.5",
+        "netmask": "^1.0.6",
+        "thunkify": "^2.1.2"
+      }
+    },
     "package-json": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
@@ -6215,6 +6784,22 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
       "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
       "dev": true
+    },
+    "parseqs": {
+      "version": "0.0.5",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/parseqs/-/parseqs-0.0.5.tgz",
+      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
+    },
+    "parseuri": {
+      "version": "0.0.5",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/parseuri/-/parseuri-0.0.5.tgz",
+      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
     },
     "parseurl": {
       "version": "1.3.2",
@@ -6338,8 +6923,7 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prepend-http": {
       "version": "1.0.4",
@@ -6413,6 +6997,41 @@
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.8.0"
       }
+    },
+    "proxy-agent": {
+      "version": "3.0.3",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/proxy-agent/-/proxy-agent-3.0.3.tgz",
+      "integrity": "sha512-PXVVVuH9tiQuxQltFJVSnXWuDtNr+8aNBP6XVDDCDiUuDN8eRCm+ii4/mFWmXWEA0w8jjJSlePa4LXlM4jIzNA==",
+      "requires": {
+        "agent-base": "^4.2.0",
+        "debug": "^3.1.0",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.1",
+        "lru-cache": "^4.1.2",
+        "pac-proxy-agent": "^3.0.0",
+        "proxy-from-env": "^1.0.0",
+        "socks-proxy-agent": "^4.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
+    "proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -7000,6 +7619,11 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
     },
+    "smart-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/smart-buffer/-/smart-buffer-4.0.1.tgz",
+      "integrity": "sha512-RFqinRVJVcCAL9Uh1oVqE6FZkqsyLiVOYEZ20TqIOjuX7iFVJ+zsbs4RIghnw/pTs7mZvt8ZHhvm1ZUrR4fykg=="
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -7095,6 +7719,80 @@
             "is-buffer": "^1.1.5"
           }
         }
+      }
+    },
+    "socket.io-client": {
+      "version": "2.2.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/socket.io-client/-/socket.io-client-2.2.0.tgz",
+      "integrity": "sha512-56ZrkTDbdTLmBIyfFYesgOxsjcLnwAKoN4CiPyTVkMQj3zTUh0QAx3GbvIvLpFEOvQWu92yyWICxB0u7wkVbYA==",
+      "requires": {
+        "backo2": "1.0.2",
+        "base64-arraybuffer": "0.1.5",
+        "component-bind": "1.0.0",
+        "component-emitter": "1.2.1",
+        "debug": "~3.1.0",
+        "engine.io-client": "~3.3.1",
+        "has-binary2": "~1.0.2",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "object-component": "0.0.3",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "socket.io-parser": "~3.3.0",
+        "to-array": "0.1.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "socket.io-parser": {
+      "version": "3.3.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
+      "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
+      "requires": {
+        "component-emitter": "1.2.1",
+        "debug": "~3.1.0",
+        "isarray": "2.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "isarray": {
+          "version": "2.0.1",
+          "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/isarray/-/isarray-2.0.1.tgz",
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+        }
+      }
+    },
+    "socks": {
+      "version": "2.2.2",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/socks/-/socks-2.2.2.tgz",
+      "integrity": "sha512-g6wjBnnMOZpE0ym6e0uHSddz9p3a+WsBaaYQaBaSCJYvrC4IXykQR9MNGjLQf38e9iIIhp3b1/Zk8YZI3KGJ0Q==",
+      "requires": {
+        "ip": "^1.1.5",
+        "smart-buffer": "^4.0.1"
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/socks-proxy-agent/-/socks-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-Kezx6/VBguXOsEe5oU3lXYyKMi4+gva72TwJ7pQY5JfqUx2nMk7NXA6z/mpNqIlfQjWYVfeuNvQjexiTaTn6Nw==",
+      "requires": {
+        "agent-base": "~4.2.0",
+        "socks": "~2.2.0"
       }
     },
     "source-map": {
@@ -7389,6 +8087,20 @@
         }
       }
     },
+    "tar-stream": {
+      "version": "1.6.2",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+      "requires": {
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
+        "xtend": "^4.0.0"
+      }
+    },
     "term-size": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
@@ -7518,6 +8230,11 @@
       "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
+    "thunkify": {
+      "version": "2.1.2",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/thunkify/-/thunkify-2.1.2.tgz",
+      "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0="
+    },
     "timed-out": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
@@ -7536,6 +8253,16 @@
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
       "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
       "dev": true
+    },
+    "to-array": {
+      "version": "0.1.4",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/to-array/-/to-array-0.1.4.tgz",
+      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
+    },
+    "to-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
     },
     "to-fast-properties": {
       "version": "1.0.3",
@@ -7727,7 +8454,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -7787,11 +8513,6 @@
       "requires": {
         "debug": "^2.2.0"
       }
-    },
-    "underscore": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
     },
     "union-value": {
       "version": "1.0.0",
@@ -8243,8 +8964,7 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
     },
     "wrap-ansi": {
       "version": "2.1.0",
@@ -8350,11 +9070,20 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
+    "xmlhttprequest-ssl": {
+      "version": "1.5.5",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
+    },
+    "xregexp": {
+      "version": "2.0.0",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/xregexp/-/xregexp-2.0.0.tgz",
+      "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
+    },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
       "version": "3.2.1",
@@ -8413,6 +9142,21 @@
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         }
+      }
+    },
+    "yeast": {
+      "version": "0.1.2",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/yeast/-/yeast-0.1.2.tgz",
+      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
+    },
+    "zip-stream": {
+      "version": "2.0.1",
+      "resolved": "https://nexus.ltfinc.net/repository/lttnpm-public/zip-stream/-/zip-stream-2.0.1.tgz",
+      "integrity": "sha512-c+eUhhkDpaK87G/py74wvWLtz2kzMPNCCkUApkun50ssE0oQliIQzWpTnwjB+MTKVIf2tGzIgHyqW/Y+W77ecQ==",
+      "requires": {
+        "archiver-utils": "^2.0.0",
+        "compress-commons": "^1.2.0",
+        "readable-stream": "^2.0.0"
       }
     }
   }

--- a/jovo-cli/package.json
+++ b/jovo-cli/package.json
@@ -32,7 +32,6 @@
 		"jovo-cli-platform-alexa": "^2.0.2-beta.0",
 		"jovo-cli-platform-google": "^2.0.2-beta.0",
 		"jovo-webhook-connector": "^2.0.2-beta.0",
-		"jsonlint": "^1.6.3",
 		"listr": "^0.14.2",
 		"lodash": "^4.17.11",
 		"nodemon": "^1.18.7",
@@ -83,6 +82,7 @@
 		"transform": {
 			"^.+\\.tsx?$": "ts-jest"
 		},
+		"testEnvironment": "node",
 		"testURL": "http://localhost/",
 		"testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
 		"testPathIgnorePatterns": [

--- a/jovo-cli/test/build.test.ts
+++ b/jovo-cli/test/build.test.ts
@@ -1,12 +1,10 @@
 const tmpTestfolder = 'tmpTestfolderBuild';
 
 import 'jest';
-import * as childProcess from 'child_process';
+import { execFile } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { deleteFolderRecursive } from '../utils/Utils';
-
-const spawn = childProcess.spawn;
 
 beforeAll((done) => {
 	deleteFolderRecursive(tmpTestfolder);
@@ -21,27 +19,22 @@ describe('build v1', () => {
 	it('jovo new <project> --init alexaSkill --v1 \n      jovo build', (done) => {
 		const projectName = 'helloworld_v1';
 		const projectFolder = path.join(tmpTestfolder, projectName);
-		const child = spawn('node', ['./../dist/index.js', 'new', projectName,
+
+		execFile('node', ['./../dist/index.js', 'new', projectName,
 			'-t', 'helloworldtest',
 			'--init', 'alexaSkill',
 			'--skip-npminstall',
 			'--v1'], {
 				cwd: tmpTestfolder,
-			});
-		child.stderr.on('data', (data) => {
-			console.log(data.toString());
-			done();
-		});
-		child.stdout.on('data', (data) => {
-			if (data.indexOf('Installation completed.') > -1) {
-				child.kill();
-				const childBuild = spawn('node', ['./../../dist/index.js',
+			}, (error, stdout, stderr) => {
+				expect(stdout).toContain('Installation completed.');
+
+				execFile('node', ['./../../dist/index.js',
 					'build'], {
 						cwd: projectFolder,
-					});
-				childBuild.stdout.on('data', (data) => {
-					if (data.indexOf('Build completed.') > -1) {
-						childBuild.kill();
+					}, (errorBuild, stdoutBuild, stderrBuild) => {
+						expect(stdoutBuild).toContain('Build completed.');
+
 						expect(fs.existsSync(path.join(projectFolder, 'platforms')))
 							.toBe(true);
 						expect(fs.existsSync(path.join(projectFolder, 'platforms', 'alexaSkill')))
@@ -64,34 +57,30 @@ describe('build v1', () => {
 							.toBe('my test app');
 						done();
 					}
-				});
+				);
 			}
-		});
+		);
 	}, 12000);
+
 	it('jovo new <project> --init googleAction --v1 \n      jovo build', (done) => {
 		const projectName = 'helloworld2_v1';
 		const projectFolder = path.join(tmpTestfolder, projectName);
-		const child = spawn('node', ['./../dist/index.js', 'new', projectName,
+
+		execFile('node', ['./../dist/index.js', 'new', projectName,
 			'-t', 'helloworldtest',
 			'--init', 'googleAction',
 			'--skip-npminstall',
 			'--v1'], {
 				cwd: tmpTestfolder,
-			});
-		child.stderr.on('data', (data) => {
-			console.log(data.toString());
-			done();
-		});
-		child.stdout.on('data', (data) => {
-			if (data.indexOf('Installation completed.') > -1) {
-				child.kill();
-				const childBuild = spawn('node', ['./../../dist/index.js',
+			}, (error, stdout, stderr) => {
+				expect(stdout).toContain('Installation completed.');
+
+				execFile('node', ['./../../dist/index.js',
 					'build'], {
 						cwd: projectFolder,
-					});
-				childBuild.stdout.on('data', (data) => {
-					if (data.indexOf('Build completed.') > -1) {
-						childBuild.kill();
+					}, (errorBuild, stdoutBuild, stderrBuild) => {
+						expect(stdoutBuild).toContain('Build completed.');
+
 						expect(
 							fs.existsSync(path.join(projectFolder,
 								'platforms')))
@@ -188,45 +177,34 @@ describe('build v1', () => {
 							.toBe(true);
 						done();
 					}
-				});
+				);
 			}
-		});
+		);
 	}, 12000);
 
 	it('jovo new <project> --init alexaSkill --build --v1 \n      jovo build --reverse', (done) => {
 		const projectName = 'helloworld_reverse_alexaSkill_v1';
 		const projectFolder = path.join(tmpTestfolder, projectName);
-		const child = spawn('node', ['./../dist/index.js', 'new', projectName,
+
+		execFile('node', ['./../dist/index.js', 'new', projectName,
 			'-t', 'helloworldtest',
 			'--init', 'alexaSkill',
 			'--build',
 			'--skip-npminstall',
 			'--v1'], {
 				cwd: tmpTestfolder,
-			});
-		child.stderr.on('data', (data) => {
-			console.log(data.toString());
-			done();
-		});
-		child.stdout.on('data', (data) => {
-			if (data.indexOf('Installation completed.') > -1) {
-				child.kill();
+			}, (error, stdout, stderr) => {
+                expect(stdout).toContain('Installation completed.');
 
 				fs.unlinkSync(path.join(projectFolder, 'models', 'en-US.json'));
 
-				const childBuild = spawn('node', ['./../../dist/index.js',
+				execFile('node', ['./../../dist/index.js',
 					'build',
 					'--reverse'], {
 						cwd: projectFolder,
-					});
+					}, (errorBuild, stdoutBuild, stderrBuild) => {
+						expect(stdoutBuild).toContain('Build completed.');
 
-				childBuild.stderr.on('data', (data) => {
-					console.log(data.toString());
-					done();
-				});
-				childBuild.stdout.on('data', (data) => {
-					if (data.indexOf('Build completed.') > -1) {
-						childBuild.kill();
 						expect(fs.existsSync(path.join(projectFolder, 'models', 'en-US.json'))).toBe(true);
 						const modelJson = JSON.parse(
 							fs.readFileSync(path.join(
@@ -237,44 +215,33 @@ describe('build v1', () => {
 							.toBe('my test app');
 						done();
 					}
-				});
+				);
 			}
-		});
+		);
 	}, 12000);
 
 	it('jovo new <project> --init googleAction --build --v1 \n      jovo build --reverse', (done) => {
 		const projectName = 'helloworld_reverse_googleAction_v1';
 		const projectFolder = path.join(tmpTestfolder, projectName);
-		const child = spawn('node', ['./../dist/index.js', 'new', projectName,
+
+		execFile('node', ['./../dist/index.js', 'new', projectName,
 			'-t', 'helloworldtest',
 			'--init', 'googleAction',
 			'--build',
 			'--skip-npminstall',
 			'--v1'], {
 				cwd: tmpTestfolder,
-			});
-		child.stderr.on('data', (data) => {
-			console.log(data.toString());
-			done();
-		});
-		child.stdout.on('data', (data) => {
-			if (data.indexOf('Installation completed.') > -1) {
-				child.kill();
+			}, (error, stdout, stderr) => {
+                expect(stdout).toContain('Installation completed.');
 
 				fs.unlinkSync(path.join(projectFolder, 'models', 'en-US.json'));
-				const childBuild = spawn('node', ['./../../dist/index.js',
+				execFile('node', ['./../../dist/index.js',
 					'build',
 					'--reverse'], {
 						cwd: projectFolder,
-					});
+					}, (errorBuild, stdoutBuild, stderrBuild) => {
+						expect(stdoutBuild).toContain('Build completed.');
 
-				childBuild.stderr.on('data', (data) => {
-					console.log(data.toString());
-					done();
-				});
-				childBuild.stdout.on('data', (data) => {
-					if (data.indexOf('Build completed.') > -1) {
-						childBuild.kill();
 						expect(fs.existsSync(path.join(projectFolder, 'models', 'en.json'))).toBe(true);
 						const modelJson = JSON.parse(
 							fs.readFileSync(path.join(
@@ -285,9 +252,9 @@ describe('build v1', () => {
 							.toBe(true);
 						done();
 					}
-				});
+				);
 			}
-		});
+		);
 	}, 12000);
 });
 
@@ -296,26 +263,21 @@ describe('build v2', () => {
 	it('jovo new <project>\n      jovo build --platform alexaSkill', (done) => {
 		const projectName = 'helloworld_v2';
 		const projectFolder = path.join(tmpTestfolder, projectName);
-		const child = spawn('node', ['./../dist/index.js', 'new', projectName,
+
+		execFile('node', ['./../dist/index.js', 'new', projectName,
 			'-t', 'helloworldtest',
 			'--skip-npminstall'], {
 				cwd: tmpTestfolder,
-			});
-		child.stderr.on('data', (data) => {
-			console.log(data.toString());
-			done();
-		});
-		child.stdout.on('data', (data) => {
-			if (data.indexOf('Installation completed.') > -1) {
-				child.kill();
-				const childBuild = spawn('node', ['./../../dist/index.js',
+			}, (error, stdout, stderr) => {
+                expect(stdout).toContain('Installation completed.');
+
+				execFile('node', ['./../../dist/index.js',
 					'build',
 					'platform', 'alexaSkill'], {
 						cwd: projectFolder,
-					});
-				childBuild.stdout.on('data', (data) => {
-					if (data.indexOf('Build completed.') > -1) {
-						childBuild.kill();
+					}, (errorBuild, stdoutBuild, stderrBuild) => {
+                        expect(stdoutBuild).toContain('Build completed.');
+
 						expect(
 							fs.existsSync(path.join(projectFolder,
 								'platforms')))
@@ -341,34 +303,29 @@ describe('build v2', () => {
 							.toBe('my test app');
 						done();
 					}
-				});
+				);
 			}
-		});
+		);
 	}, 12000);
 
 	it('jovo new <project>\n      jovo build --platform googleAction', (done) => {
 		const projectName = 'helloworld2_v2';
 		const projectFolder = path.join(tmpTestfolder, projectName);
-		const child = spawn('node', ['./../dist/index.js', 'new', projectName,
+
+		execFile('node', ['./../dist/index.js', 'new', projectName,
 			'-t', 'helloworldtest',
 			'--skip-npminstall'], {
 				cwd: tmpTestfolder,
-			});
-		child.stderr.on('data', (data) => {
-			console.log(data.toString());
-			done();
-		});
-		child.stdout.on('data', (data) => {
-			if (data.indexOf('Installation completed.') > -1) {
-				child.kill();
-				const childBuild = spawn('node', ['./../../dist/index.js',
+			}, (error, stdout, stderr) => {
+				expect(stdout).toContain('Installation completed.');
+
+				execFile('node', ['./../../dist/index.js',
 					'build',
 					'--platform', 'googleAction'], {
 						cwd: projectFolder,
-					});
-				childBuild.stdout.on('data', (data) => {
-					if (data.indexOf('Build completed.') > -1) {
-						childBuild.kill();
+					}, (errorBuild, stdoutBuild, stderrBuild) => {
+						expect(stdoutBuild).toContain('Build completed.');
+
 						expect(
 							fs.existsSync(path.join(projectFolder,
 								'platforms')))
@@ -466,43 +423,33 @@ describe('build v2', () => {
 							.toBe(true);
 						done();
 					}
-				});
+				);
 			}
-		});
+		);
 	}, 12000);
 
 	it('jovo new <project> --build alexaSkill\n      jovo build --platform alexaSkill --reverse', (done) => {
 		const projectName = 'helloworld_reverse_alexaSkill_v2';
 		const projectFolder = path.join(tmpTestfolder, projectName);
-		const child = spawn('node', ['./../dist/index.js', 'new', projectName,
+
+		execFile('node', ['./../dist/index.js', 'new', projectName,
 			'-t', 'helloworldtest',
 			'--build', 'alexaSkill',
 			'--skip-npminstall'], {
 				cwd: tmpTestfolder,
-			});
-		child.stderr.on('data', (data) => {
-			console.log(data.toString());
-			done();
-		});
-		child.stdout.on('data', (data) => {
-			if (data.indexOf('Installation completed.') > -1) {
-				child.kill();
+			}, (error, stdout, stderr) => {
+				expect(stdout).toContain('Installation completed.');
 
 				fs.unlinkSync(path.join(projectFolder, 'models', 'en-US.json'));
 
-				const childBuild = spawn('node', ['./../../dist/index.js',
+				execFile('node', ['./../../dist/index.js',
 					'build',
 					'--platform', 'alexaSkill',
 					'--reverse'], {
 						cwd: projectFolder,
-					});
+					}, (errorBuild, stdoutBuild, stderrBuild) => {
+						expect(stdoutBuild).toContain('Build completed.');
 
-				childBuild.stderr.on('data', (data) => {
-					done();
-				});
-				childBuild.stdout.on('data', (data) => {
-					if (data.indexOf('Build completed.') > -1) {
-						childBuild.kill();
 						expect(fs.existsSync(path.join(projectFolder, 'models', 'en-US.json'))).toBe(true);
 						const modelJson = JSON.parse(
 							fs.readFileSync(path.join(
@@ -513,43 +460,32 @@ describe('build v2', () => {
 							.toBe('my test app');
 						done();
 					}
-				});
+				);
 			}
-		});
+		);
 	}, 12000);
 
 	it('jovo new <project> --build googleAction\n      jovo build --platform googleAction --reverse', (done) => {
 		const projectName = 'helloworld_reverse_googleAction_v2';
 		const projectFolder = path.join(tmpTestfolder, projectName);
-		const child = spawn('node', ['./../dist/index.js', 'new', projectName,
+
+		execFile('node', ['./../dist/index.js', 'new', projectName,
 			'-t', 'helloworldtest',
 			'--build', 'googleAction',
 			'--skip-npminstall'], {
 				cwd: tmpTestfolder,
-			});
-		child.stderr.on('data', (data) => {
-			console.log(data.toString());
-			done();
-		});
-		child.stdout.on('data', (data) => {
-			if (data.indexOf('Installation completed.') > -1) {
-				child.kill();
+			}, (error, stdout, stderr) => {
+				expect(stdout).toContain('Installation completed.');
 
 				fs.unlinkSync(path.join(projectFolder, 'models', 'en-US.json'));
-				const childBuild = spawn('node', ['./../../dist/index.js',
+				execFile('node', ['./../../dist/index.js',
 					'build',
 					'--platform', 'googleAction',
 					'--reverse'], {
 						cwd: projectFolder,
-					});
+					}, (errorBuild, stdoutBuild, stderrBuild) => {
+						expect(stdoutBuild).toContain('Build completed.');
 
-				childBuild.stderr.on('data', (data) => {
-					console.log(data.toString());
-					done();
-				});
-				childBuild.stdout.on('data', (data) => {
-					if (data.indexOf('Build completed.') > -1) {
-						childBuild.kill();
 						expect(fs.existsSync(path.join(projectFolder, 'models', 'en.json'))).toBe(true);
 						const modelJson = JSON.parse(
 							fs.readFileSync(path.join(
@@ -560,9 +496,39 @@ describe('build v2', () => {
 							.toBe(true);
 						done();
 					}
-				});
+				);
 			}
-		});
+		);
+	}, 12000);
+
+	it('jovo build fails if model JSON is invalid', (done) => {
+		const projectName = 'helloworld_v2';
+		const projectFolder = path.join(tmpTestfolder, projectName);
+
+		execFile('node', ['./../dist/index.js', 'new', projectName,
+			'-t', 'helloworldtest',
+			'--skip-npminstall'], {
+				cwd: tmpTestfolder,
+			}, (error, stdout, stderr) => {
+				expect(stdout).toContain('Installation completed.');
+
+				// make the model JSON invalid by appending an extra character to it
+				fs.appendFileSync(path.join(projectFolder, 'models', 'en-US.json'), 'z');
+
+				// verify that doing 'jovo build' properly outputs a model validation error
+				execFile('node', ['./../../dist/index.js',
+					'build',
+					'platform', 'alexaSkill'], {
+						cwd: projectFolder,
+					}, (errorBuild, stdoutBuild, stderrBuild) => {
+						expect(stdoutBuild).toContain('Unexpected token z in JSON');
+                        expect(stdoutBuild).toContain('Validate Model-Files [failed]');
+
+						done();
+					}
+				);
+			}
+		);
 	}, 12000);
 });
 

--- a/jovo-cli/test/build.test.ts
+++ b/jovo-cli/test/build.test.ts
@@ -502,7 +502,7 @@ describe('build v2', () => {
 	}, 12000);
 
 	it('jovo build fails if model JSON is invalid', (done) => {
-		const projectName = 'helloworld_v2';
+		const projectName = 'helloworld_invalid_model_json_v2';
 		const projectFolder = path.join(tmpTestfolder, projectName);
 
 		execFile('node', ['./../dist/index.js', 'new', projectName,


### PR DESCRIPTION
## Proposed changes
The jsonlint package uses old/deprecated packages and has a notice on their website `I'm not sure why you wouldn't use the built in JSON.parse`, so this PR removes jsonlint and replaces its usage with JSON.parse. I've added a test and also simplified other tests in the same file as well (basically porting part of https://github.com/jovotech/jovo-cli/pull/64 to v2)

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed