### PR TITLE
:lipstick: Increase line width to accomodate ARNs in status messages

### DIFF
--- a/jovo-cli/utils/JovoRenderer.ts
+++ b/jovo-cli/utils/JovoRenderer.ts
@@ -15,7 +15,7 @@ const intdentText = (text: string, level: number, indentText = '    ', color: st
 	}
 
 	const indentLength = level * indentString.length;
-	const maxLength = 80;
+	const maxLength = 120;
 	const maxTextLength = maxLength - indentLength;
 
 	let textLeft = text;


### PR DESCRIPTION
## Proposed changes
Lambda ARNs in the status messages exceed the previous line width of 80 and caused line wraps with few characters in the new line. This commit increases the line with to 120.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed