### PR TITLE
🐛 Resolve ask-profile for ask-cli@v1, Fix problem with ask-cli@v2…

### DIFF
--- a/jovo-cli/test/deploy.test.ts
+++ b/jovo-cli/test/deploy.test.ts
@@ -64,7 +64,7 @@ describe('deploy', () => {
     }
 
     expect(skillId.length > 0).toBe(true);
-    await deleteSkill(skillId);
+    await deleteSkill(askVersion, process.env.ASK_PROFILE, skillId);
   }, 200000);
 
   it('jovo new <project> --build\n      jovo deploy --target zip', async () => {
@@ -135,19 +135,23 @@ describe('deploy', () => {
  * @param {string} skillId
  * @param {function} callback
  */
-async function deleteSkill(skillId: string) {
+async function deleteSkill(askVersion: string, askProfile: string, skillId: string) {
   return new Promise((resolve, reject) => {
-    exec('ask api delete-skill --skill-id ' + skillId, {}, (error, stdout, stderr) => {
+    const cmd =
+      `ask ${askVersion === '2' ? 'smapi' : 'api'} delete-skill ` +
+      `--skill-id ${skillId} ` +
+      `--profile ${askProfile}`;
+
+    exec(cmd, {}, (error, stdout, stderr) => {
       if (error) {
-        console.log(error);
-        if (stderr) {
-          console.log(stderr);
-        }
         reject(error);
       }
-      if (stdout.indexOf('Skill deleted successfully.') > -1) {
-        resolve();
+
+      if (stderr) {
+        reject(stderr);
       }
+
+      resolve();
     });
   });
 }

--- a/packages/jovo-cli-platform-alexa/src/Ask.ts
+++ b/packages/jovo-cli-platform-alexa/src/Ask.ts
@@ -97,17 +97,17 @@ export function prepareSkillList(askSkill: AskSkillList) {
 
 /**
  * Creates skill in ASK
- * @param {*} config
+ * @param {*} ctx
  * @param {string} skillJsonPath
  * @return {Promise<any>}
  */
 export function askApiCreateSkill(
-  config: JovoTaskContextAlexa,
+  ctx: JovoTaskContextAlexa,
   skillJsonPath: string,
 ): Promise<string> {
   return new Promise((resolve, reject) => {
     exec(
-      'ask api create-skill -f "' + skillJsonPath + '" --profile ' + config.askProfile,
+      `ask api create-skill -f "${skillJsonPath}" ${ctx.askProfile ? `-p ${ctx.askProfile}` : ''}`,
       (error, stdout, stderr) => {
         if (error) {
           if (stderr) {
@@ -125,19 +125,22 @@ export function askApiCreateSkill(
 
 /**
  * Returns list of skills that are owned by the given profile
- * @param {*} config
+ * @param {*} ctx
  * @return {Promise<any>}
  */
-export function askApiListSkills(config: JovoTaskContextAlexa): Promise<inquirer.ChoiceType[]> {
+export function askApiListSkills(ctx: JovoTaskContextAlexa): Promise<inquirer.ChoiceType[]> {
   const returnPromise = new Promise((resolve, reject) => {
-    exec('ask api list-skills --profile ' + config.askProfile, {}, (error, stdout, stderr) => {
-      if (error) {
-        if (stderr) {
-          return reject(getAskErrorV1('askApiListSkills', stderr));
+    exec(
+      `ask api list-skills ${ctx.askProfile ? `-p ${ctx.askProfile}` : ''}`,
+      (error, stdout, stderr) => {
+        if (error) {
+          if (stderr) {
+            return reject(getAskErrorV1('askApiListSkills', stderr));
+          }
         }
-      }
-      resolve(JSON.parse(stdout));
-    });
+        resolve(JSON.parse(stdout));
+      },
+    );
   });
 
   return returnPromise.then((askSkill) => {
@@ -147,27 +150,21 @@ export function askApiListSkills(config: JovoTaskContextAlexa): Promise<inquirer
 
 /**
  * Updates model of skill for the given locale
- * @param {*} config
+ * @param {*} ctx
  * @param {*} modelPath
  * @param {string} locale
  * @return {Promise<any>}
  */
 export function askApiUpdateModel(
-  config: JovoTaskContextAlexa,
+  ctx: JovoTaskContextAlexa,
   modelPath: string,
   locale: string,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     exec(
-      'ask api update-model -s ' +
-        config.skillId +
-        ' -f "' +
-        modelPath +
-        '" -l ' +
-        locale +
-        ' --profile ' +
-        config.askProfile,
-      {},
+      `ask api update-model -s ${ctx.skillId} -f ${modelPath} -l ${locale} ${
+        ctx.askProfile ? `-p ${ctx.askProfile}` : ''
+      }`,
       (error, stdout, stderr) => {
         if (error) {
           if (stderr) {
@@ -182,23 +179,16 @@ export function askApiUpdateModel(
 
 /**
  * Updates skill information
- * @param {*} config
+ * @param {*} ctx
  * @param {string} skillJsonPath
  * @return {Promise<any>}
  */
-export function askApiUpdateSkill(
-  config: JovoTaskContextAlexa,
-  skillJsonPath: string,
-): Promise<void> {
+export function askApiUpdateSkill(ctx: JovoTaskContextAlexa, skillJsonPath: string): Promise<void> {
   return new Promise((resolve, reject) => {
     exec(
-      'ask api update-skill -s ' +
-        config.skillId +
-        ' -f "' +
-        skillJsonPath +
-        '" --profile ' +
-        config.askProfile,
-      {},
+      `ask api update-skill -s ${ctx.skillId} -f ${skillJsonPath} ${
+        ctx.askProfile ? `-p ${ctx.askProfile}` : ''
+      }`,
       (error, stdout, stderr) => {
         if (error) {
           if (stderr) {
@@ -213,43 +203,39 @@ export function askApiUpdateSkill(
 
 /**
  * Gets build status of model
- * @param {*} config
+ * @param {*} ctx
  * @return {Promise<any>}
  */
-export function askApiGetSkillStatus(config: JovoTaskContextAlexa): Promise<object> {
+export function askApiGetSkillStatus(ctx: JovoTaskContextAlexa): Promise<object> {
   return new Promise((resolve, reject) => {
-    const command =
-      'ask api get-skill-status -s ' + config.skillId + ' --profile ' + config.askProfile;
-    exec(command, {}, (error, stdout, stderr) => {
-      if (error) {
-        if (stderr) {
-          return reject(getAskErrorV1('askApiGetSkillStatus', stderr));
+    exec(
+      `ask api get-skill-status -s ${ctx.skillId} ${ctx.askProfile ? `-p ${ctx.askProfile}` : ''}`,
+      (error, stdout, stderr) => {
+        if (error) {
+          if (stderr) {
+            return reject(getAskErrorV1('askApiGetSkillStatus', stderr));
+          }
         }
-      }
-      try {
-        resolve(JSON.parse(stdout));
-      } catch (error) {
-        reject(error);
-      }
-    });
+        try {
+          resolve(JSON.parse(stdout));
+        } catch (error) {
+          reject(error);
+        }
+      },
+    );
   });
 }
 
 /**
  * Saves skill information to json file
- * @param {*} config
+ * @param {*} ctx
  * @param {string} skillJsonPath
  * @return {Promise<any>}
  */
-export function askApiGetSkill(config: JovoTaskContextAlexa, skillJsonPath: string): Promise<void> {
+export function askApiGetSkill(ctx: JovoTaskContextAlexa, skillJsonPath: string): Promise<void> {
   return new Promise((resolve, reject) => {
     exec(
-      'ask api get-skill -s ' +
-        config.skillId +
-        ' > "' +
-        skillJsonPath +
-        '" --profile ' +
-        config.askProfile,
+      `ask api get-skill -s ${ctx.skillId} > "${skillJsonPath}" ${ctx.askProfile ? `-p ${ctx.askProfile}` : ''}`,
       (error, stdout, stderr) => {
         if (error) {
           if (stderr) {
@@ -264,27 +250,19 @@ export function askApiGetSkill(config: JovoTaskContextAlexa, skillJsonPath: stri
 
 /**
  * Saves model to file
- * @param {*} config
+ * @param {*} ctx
  * @param {string} skillJsonPath
  * @param {string} locale
  * @return {Promise<any>}
  */
 export function askApiGetModel(
-  config: JovoTaskContextAlexa,
+  ctx: JovoTaskContextAlexa,
   skillJsonPath: string,
   locale: string,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     exec(
-      'ask api get-model -s ' +
-        config.skillId +
-        ' -l ' +
-        locale +
-        ' > "' +
-        skillJsonPath +
-        '" --profile ' +
-        config.askProfile,
-      {},
+      `ask api get-model -s ${ctx.skillId} -l ${locale} > "${skillJsonPath}" ${ctx.askProfile ? `-p ${ctx.askProfile}` : ''}`,
       (error, stdout, stderr) => {
         if (error) {
           if (stderr) {
@@ -299,14 +277,13 @@ export function askApiGetModel(
 
 /**
  * Saves model to file
- * @param {*} config
+ * @param {*} ctx
  * @return {Promise<any>}
  */
-export function askApiEnableSkill(config: JovoTaskContextAlexa): Promise<void> {
+export function askApiEnableSkill(ctx: JovoTaskContextAlexa): Promise<void> {
   return new Promise((resolve, reject) => {
     exec(
-      'ask api enable-skill -s ' + config.skillId + ' --profile ' + config.askProfile,
-      {},
+      `ask api enable-skill -s ${ctx.skillId} ${ctx.askProfile ? `-p ${ctx.askProfile}` : ''}`,
       (error, stdout, stderr) => {
         if (error) {
           if (stderr) {
@@ -321,13 +298,13 @@ export function askApiEnableSkill(config: JovoTaskContextAlexa): Promise<void> {
 
 /**
  * Saves account linking information to file
- * @param {*} config
+ * @param {*} ctx
  * @return {Promise<any>}
  */
-export function askApiGetAccountLinking(config: JovoTaskContextAlexa): Promise<string> {
+export function askApiGetAccountLinking(ctx: JovoTaskContextAlexa): Promise<string> {
   return new Promise((resolve, reject) => {
     exec(
-      'ask api get-account-linking -s ' + config.skillId + ' --profile ' + config.askProfile,
+      `ask api get-account-linking -s ${ctx.skillId} ${ctx.askProfile ? `-p ${ctx.askProfile}` : ''}`,
       {},
       (error, stdout, stderr) => {
         if (error) {

--- a/packages/jovo-cli-platform-alexa/src/Platform.ts
+++ b/packages/jovo-cli-platform-alexa/src/Platform.ts
@@ -563,7 +563,7 @@ Endpoint: ${skillInfo.endpoint}`;
               // Apply the changes to the current model-file if one exists
               let modelFile;
               try {
-                modelFile = await project.getModel(locale);
+                modelFile = project.getModel(locale);
               } catch (e) {
                 // Currently no model file exists so there is
                 // nothing to merge it with
@@ -825,6 +825,14 @@ Endpoint: ${skillInfo.endpoint}`;
    * @memberof JovoCliPlatformAlexa
    */
   getLocales(locale?: string | string[]): string[] {
+    //! Since the locales will be fetched from inside the /platforms/alexaSkill/ folder,
+    //! we need to check for the ask-cli version to read the correct model files.
+    try {
+      this.askVersion = ask.checkAsk();
+    } catch (err) {
+      this.askVersion = '2';
+    }
+
     try {
       if (locale) {
         if (Array.isArray(locale)) {

--- a/packages/jovo-cli-platform-alexa/src/smapi/AccountLinkingManagement.ts
+++ b/packages/jovo-cli-platform-alexa/src/smapi/AccountLinkingManagement.ts
@@ -1,16 +1,18 @@
 import { pathExistsSync, readFileSync } from 'fs-extra';
-import { JovoCliError } from 'jovo-cli-core';
 
-import { JovoTaskContextAlexa, execAsync, getAskErrorV2 } from '../utils';
+import { execAsync, JovoTaskContextAlexa, getAskErrorV2 } from '../utils';
 
 export async function getAccountLinkingInformation(ctx: JovoTaskContextAlexa, stage: string) {
   try {
-    const stdout = await execAsync(
-      `ask smapi get-account-linking-info -s ${ctx.skillId} -g ${stage} ${
-        ctx.askProfile ? `-p ${ctx.askProfile}` : ''
-      }`,
-    );
+    const cmd =
+      'ask smapi get-account-linking-info ' +
+      `-s ${ctx.skillId} ` +
+      `-g ${stage} ` +
+      `${ctx.askProfile ? `-p ${ctx.askProfile}` : ''}`;
+
+    const stdout = await execAsync(cmd);
     const response = JSON.parse(stdout);
+
     return response.accountLinkingResponse;
   } catch (err) {
     if (err.code === 1) {
@@ -31,9 +33,12 @@ export async function updateAccountLinkingInformation(
       return;
     }
 
-    const cmd = `ask smapi update-account-linking-info -s ${ctx.skillId} -g ${stage} ${
-      ctx.askProfile ? `-p ${ctx.askProfile}` : ''
-    } --account-linking-request "file:${accountLinkingJsonPath}"`;
+    const cmd =
+      'ask smapi update-account-linking-info ' +
+      `-s ${ctx.skillId} ` +
+      `-g ${stage} ` +
+      `${ctx.askProfile ? `-p ${ctx.askProfile}` : ''} ` +
+      `--account-linking-request "file:${accountLinkingJsonPath}"`;
 
     await execAsync(cmd);
   } catch (err) {

--- a/packages/jovo-cli-platform-alexa/src/smapi/InteractionModelManagement.ts
+++ b/packages/jovo-cli-platform-alexa/src/smapi/InteractionModelManagement.ts
@@ -1,17 +1,21 @@
-import { writeFileSync, readFileSync } from 'fs-extra';
+import { writeFileSync } from 'fs-extra';
 
-import { JovoTaskContextAlexa, execAsync, getAskErrorV2 } from '../utils';
+import { execAsync, JovoTaskContextAlexa, getAskErrorV2 } from '../utils';
 
 export async function updateInteractionModel(
   ctx: JovoTaskContextAlexa,
   locale: string,
   interactionModelPath: string,
   stage: string,
-): Promise<void> {
+) {
   try {
-    const cmd = `ask smapi set-interaction-model -s ${ctx.skillId} -g ${stage} -l ${locale} ${
-      ctx.askProfile ? `-p ${ctx.askProfile}` : ''
-    } --interaction-model "file:${interactionModelPath}"`;
+    const cmd =
+      'ask smapi set-interaction-model ' +
+      `-s ${ctx.skillId} ` +
+      `-g ${stage} ` +
+      `-l ${locale} ` +
+      `${ctx.askProfile ? `-p ${ctx.askProfile}` : ''} ` +
+      `--interaction-model "file:${interactionModelPath}"`;
 
     await execAsync(cmd);
   } catch (err) {
@@ -26,12 +30,16 @@ export async function getInteractionModel(
   stage: string,
 ) {
   try {
-    const stdout = await execAsync(
-      `ask smapi get-interaction-model -s ${ctx.skillId} -g ${stage} -l ${locale} ${
-        ctx.askProfile ? `-p ${ctx.askProfile}` : ''
-      }`,
-    );
+    const cmd =
+      'ask smapi get-interaction-model ' +
+      `-s ${ctx.skillId} ` +
+      `-g ${stage} ` +
+      `-l ${locale} ` +
+      `${ctx.askProfile ? `-p ${ctx.askProfile}` : ''}`;
+
+    const stdout = await execAsync(cmd);
     const response = JSON.parse(stdout);
+
     writeFileSync(modelPath, JSON.stringify(response, null, '\t'));
   } catch (err) {
     throw getAskErrorV2('smapiGetInteractionModel', err.message);

--- a/packages/jovo-cli-platform-alexa/src/smapi/SkillEnablement.ts
+++ b/packages/jovo-cli-platform-alexa/src/smapi/SkillEnablement.ts
@@ -1,14 +1,14 @@
-import { JovoCliError } from 'jovo-cli-core';
+import { execAsync, JovoTaskContextAlexa, getAskErrorV2 } from '../utils';
 
-import { JovoTaskContextAlexa, execAsync, getAskErrorV2 } from '../utils';
-
-export async function enableSkill(ctx: JovoTaskContextAlexa, stage: string): Promise<void> {
+export async function enableSkill(ctx: JovoTaskContextAlexa, stage: string) {
   try {
-    await execAsync(
-      `ask smapi set-skill-enablement -s ${ctx.skillId} -g ${stage} ${
-        ctx.askProfile ? `-p ${ctx.askProfile}` : ''
-      }`,
-    );
+    const cmd =
+      'ask smapi set-skill-enablement ' +
+      `-s ${ctx.skillId} ` +
+      `-g ${stage} ` +
+      `${ctx.askProfile ? `-p ${ctx.askProfile}` : ''}`;
+
+    await execAsync(cmd);
   } catch (err) {
     throw getAskErrorV2('smapiEnableSkill', err.message);
   }

--- a/packages/jovo-cli-platform-alexa/src/smapi/SkillManagement.ts
+++ b/packages/jovo-cli-platform-alexa/src/smapi/SkillManagement.ts
@@ -1,18 +1,17 @@
-import { Utils, JovoCliError } from 'jovo-cli-core';
-import { writeFileSync, readFileSync } from 'fs-extra';
-import { ChoiceType } from 'inquirer';
+import { Utils } from 'jovo-cli-core';
+import { writeFileSync } from 'fs-extra';
 
-import { JovoTaskContextAlexa, AskSkillList, execAsync, getAskErrorV2 } from '../utils';
+import { JovoTaskContextAlexa, AskSkillList, getAskErrorV2, execAsync } from '../utils';
 import { prepareSkillList } from '../Ask';
 
 export async function getSkillStatus(ctx: JovoTaskContextAlexa) {
   try {
-    const stdout = await execAsync(
-      `ask smapi get-skill-status -s ${ctx.skillId} ${
-        ctx.askProfile ? `-p ${ctx.askProfile}` : ''
-      }`,
-    );
+    const cmd =
+      'ask smapi get-skill-status ' +
+      `-s ${ctx.skillId} ` +
+      `${ctx.askProfile ? `-p ${ctx.askProfile}` : ''}`;
 
+    const stdout = await execAsync(cmd);
     const response = JSON.parse(stdout);
 
     if (response.manifest) {
@@ -41,29 +40,30 @@ export async function getSkillStatus(ctx: JovoTaskContextAlexa) {
   }
 }
 
-export async function createSkill(
-  ctx: JovoTaskContextAlexa,
-  skillJsonPath: string,
-): Promise<string> {
+export async function createSkill(ctx: JovoTaskContextAlexa, skillJsonPath: string) {
   try {
-    const cmd = `ask smapi create-skill-for-vendor ${
-      ctx.askProfile ? `-p ${ctx.askProfile}` : ''
-    } --manifest "file:${skillJsonPath}"`;
+    const cmd =
+      'ask smapi create-skill-for-vendor ' +
+      `${ctx.askProfile ? `-p ${ctx.askProfile}` : ''} ` +
+      `--manifest "file:${skillJsonPath}"`;
 
     const stdout = await execAsync(cmd);
+    const response = JSON.parse(stdout);
 
-    const { skillId } = JSON.parse(stdout);
-    return skillId;
+    return response.skillId;
   } catch (err) {
     throw getAskErrorV2('smapiCreateSkill', err.message);
   }
 }
 
-export async function updateSkill(ctx: JovoTaskContextAlexa, skillJsonPath: string): Promise<void> {
+export async function updateSkill(ctx: JovoTaskContextAlexa, skillJsonPath: string) {
   try {
-    const cmd = `ask smapi update-skill-manifest -s ${ctx.skillId} -g development ${
-      ctx.askProfile ? `-p ${ctx.askProfile}` : ''
-    } --manifest "file:${skillJsonPath}"`;
+    const cmd =
+      'ask smapi update-skill-manifest ' +
+      `-s ${ctx.skillId} ` +
+      `-g development ` +
+      `${ctx.askProfile ? `-p ${ctx.askProfile}` : ''} ` +
+      `--manifest "file:${skillJsonPath}"`;
 
     await execAsync(cmd);
   } catch (err) {
@@ -77,12 +77,13 @@ export async function getSkillInformation(
   stage: string,
 ) {
   try {
-    const stdout = await execAsync(
-      `ask smapi get-skill-manifest -s ${ctx.skillId} -g ${stage} ${
-        ctx.askProfile ? `-p ${ctx.askProfile}` : ''
-      }`,
-    );
+    const cmd =
+      'ask smapi get-skill-manifest ' +
+      `-s ${ctx.skillId} ` +
+      `-g ${stage} ` +
+      `${ctx.askProfile ? `-p ${ctx.askProfile}` : ''}`;
 
+    const stdout = await execAsync(cmd);
     const response = JSON.parse(stdout);
 
     writeFileSync(skillJsonPath, JSON.stringify(response, null, '\t'));
@@ -91,12 +92,13 @@ export async function getSkillInformation(
   }
 }
 
-export async function listSkills(ctx: JovoTaskContextAlexa): Promise<ChoiceType[]> {
+export async function listSkills(ctx: JovoTaskContextAlexa) {
   try {
-    const stdout = await execAsync(
-      `ask smapi list-skills-for-vendor ${ctx.askProfile ? `-p ${ctx.askProfile}` : ''}`,
-    );
+    const cmd =
+      'ask smapi list-skills-for-vendor ' + 
+      `${ctx.askProfile ? `-p ${ctx.askProfile}` : ''}`;
 
+    const stdout = await execAsync(cmd);
     const response = JSON.parse(stdout);
 
     return Promise.resolve(prepareSkillList(response as AskSkillList));

--- a/packages/jovo-cli-platform-alexa/src/utils/index.ts
+++ b/packages/jovo-cli-platform-alexa/src/utils/index.ts
@@ -9,7 +9,7 @@ export function execAsync(cmd: string, options: ExecOptions = {}): Promise<strin
       if (err) {
         return rej(err);
       }
-      if (stderr) {
+      if (stderr && !stdout) {
         return rej(stderr);
       }
 


### PR DESCRIPTION
….11.1 regarding Messenger warnings

## Proposed changes
Addresses the following problems:
- As we removed the default value for the ask-profile, we had to include a check inside the `smapi.ts` handler, but didn't do so for the `Ask.ts` handler.
- With `ask-cli@v2.11.1`, a warning has been implemented for certain async operations, which caused `execAsync()` to fail. By checking for `stdout`, this has been resolved.
- Since `jovo build --reverse` checks for all available locales inside `/platforms/alexaSkill`, a check for the version of the `ask-cli` was necessary to fetch the right folder path.
- Inside `deploy.test.ts`, the function `deleteSkill()` only worked for `ask-cli@v1`, but not for `ask-cli@v2`.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed