### PR TITLE
:sparkles: Add color logging

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,3 +1,4 @@
-process.env.JOVO_CLI_RUNTIME = 'true';
+process.env.JOVO_CLI_RUNTIME = '1';
+process.env.FORCE_COLOR = '1';
 
 export { run } from '@oclif/command';


### PR DESCRIPTION
## Proposed changes
This PR adds color logging to the Jovo Framework by simply setting an environment variable according to the `chalk` docs [here](https://github.com/chalk/chalk#supportscolor).

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed