### PR TITLE
:adhesive_bandage: Enhance instance check on JovoCliError

### DIFF
--- a/core/src/PluginCommand.ts
+++ b/core/src/PluginCommand.ts
@@ -80,8 +80,14 @@ export abstract class PluginCommand<T extends Events = DefaultEvents> extends Mi
    * @param error - JovoCliError.
    */
   async catch(error: JovoCliError | Error): Promise<void> {
-    if (!(error instanceof JovoCliError)) {
-      error = new JovoCliError({ message: error.message });
+    // Since the Jovo CLI works with global and local modules,
+    // the instanceof parameter won't work at times when an error is
+    // thrown in a local and validated in a global module.
+    // Hence we must check manually if the error satisfies properties of JovoCliError.
+    if (!(error instanceof JovoCliError) && !(error as JovoCliError)['properties']) {
+      error = new JovoCliError({
+        message: error.message,
+      });
     }
     JovoCliError.print(error as JovoCliError);
     process.exit(1);


### PR DESCRIPTION
## Proposed changes
Since the Jovo CLI works with global and local modules, the `instanceof` parameter won't work at times when an error is thrown in a local and validated in a global module. Hence we must check manually if the error satisfies properties of JovoCliError.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed