### PR TITLE
:bug: Fix decorators blocking command execution

### DIFF
--- a/core/src/decorators.ts
+++ b/core/src/decorators.ts
@@ -1,4 +1,4 @@
-import { checkForProjectDirectory, PluginCommand } from '.';
+import { checkForProjectDirectory, JovoCli, PluginCommand } from '.';
 
 /**
  * Decorator that checks if the current working directory
@@ -6,11 +6,10 @@ import { checkForProjectDirectory, PluginCommand } from '.';
  */
 export function ProjectCommand(): Function {
   return (command: typeof PluginCommand) => {
-    const run = command.prototype.run;
-    command.prototype.run = async function (this: PluginCommand): Promise<void> {
-      checkForProjectDirectory(this.$cli.isInProjectDirectory());
-      await run();
-    }.bind(command.prototype);
+    if (process.argv.includes(command.id) && !process.argv.includes('help')) {
+      const cli = new JovoCli();
+      checkForProjectDirectory(cli.isInProjectDirectory());
+    }
   };
 }
 

--- a/core/src/prompts.ts
+++ b/core/src/prompts.ts
@@ -87,7 +87,7 @@ export async function promptSupportedLocales(
       type: 'multiselect',
       message: `Locale ${printHighlight(
         locale,
-      )} is not supported by ${platform}.\nPlease provide an alternative locale (type to filter, select with space):`,
+      )} is not supported by ${platform}.\n  Please provide an alternative locale (type to filter, select with space):`,
       instructions: false,
       min: 1,
       choices: supportedLocales.map((locale) => ({


### PR DESCRIPTION
## Proposed changes
The @ProjectCommand decorator bound the existing prototype to the command before parsing process.argv, which resulted in loss of relevant information.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed