### PR TITLE
:bug: Fix blinking spinner on Windows

### DIFF
--- a/core/src/Task.ts
+++ b/core/src/Task.ts
@@ -77,6 +77,9 @@ export class Task {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         this.spinner['stream'].cursorTo(this.config.indentation);
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        this.spinner['stream'].clearLine = () => {};
         this.spinner.start();
       }
 


### PR DESCRIPTION
## Proposed changes
On Windows, Ora displays the spinner with a blinking row. According to the official repository, this is a bug that won't likely get fixed. This PR introduces a "hack" around the issue by removing `this.stream.clearLine()`.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed