### PR TITLE
:bug: Set process ID to environment

### DIFF
--- a/commands/command-run/src/commands/run.ts
+++ b/commands/command-run/src/commands/run.ts
@@ -100,9 +100,9 @@ export class Run extends PluginCommand<RunEvents> {
 
     // Ensure our child process is terminated upon exit. This is needed in the situation
     // where we're on Linux and are the child of another process (grandchild processes are orphaned in Linux).
-    process.on('SIGINT', () => {
+    process.on('SIGTERM', () => {
       if (nodeProcess.pid) {
-        process.kill(nodeProcess.pid, 'SIGINT');
+        process.kill(nodeProcess.pid, 'SIGTERM');
       }
       process.exit();
     });

--- a/commands/command-run/src/commands/run.ts
+++ b/commands/command-run/src/commands/run.ts
@@ -88,6 +88,8 @@ export class Run extends PluginCommand<RunEvents> {
       process.env.JOVO_PORT = flags.port;
     }
 
+    process.env.JOVO_CLI_PROCESS_ID = `${process.pid}`;
+
     const nodeProcess: ChildProcess = spawn('npm', ['run', `start:${flags.stage || 'dev'}`], {
       shell: true,
       windowsVerbatimArguments: true,
@@ -98,8 +100,11 @@ export class Run extends PluginCommand<RunEvents> {
 
     // Ensure our child process is terminated upon exit. This is needed in the situation
     // where we're on Linux and are the child of another process (grandchild processes are orphaned in Linux).
-    process.on('exit', () => {
-      nodeProcess.kill();
+    process.on('SIGINT', () => {
+      if (nodeProcess.pid) {
+        process.kill(nodeProcess.pid, 'SIGINT');
+      }
+      process.exit();
     });
   }
 }


### PR DESCRIPTION
## Proposed changes
This PR sets the process ID of the running CLI instance to `process.env` to allow child processes to terminate it directly. This removes overhead in some situations where the node process of the running Jovo instance can be terminated, but `tsc-watch` can not due to being the parent process.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed