### PR TITLE
:ambulance: Prevent collision of exec paths

### DIFF
--- a/cli/src/Collector.ts
+++ b/cli/src/Collector.ts
@@ -8,6 +8,7 @@ import {
   PluginContext,
 } from '@jovotech/cli-core';
 import { Command, Plugin, Topic } from '@oclif/config';
+import { dirname } from 'path';
 
 export class Collector extends Plugin {
   get topics(): Topic[] {
@@ -31,6 +32,11 @@ export class Collector extends Plugin {
   async loadPlugins(commandId: string, emitter: EventEmitter): Promise<void> {
     try {
       Log.verbose('Initiating Jovo CLI');
+
+      // Set exec path before loading plugins to prevent
+      // locally installed CLI modules from colliding with the global one
+      process.env.JOVO_CLI_EXEC_PATH = dirname(__dirname);
+
       const cli: JovoCli = JovoCli.getInstance();
       const plugins: JovoCliPlugin[] = cli.loadPlugins();
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,8 +1,5 @@
-import { dirname } from 'path';
-
 process.env.FORCE_COLOR = '1';
 process.env.JOVO_CLI_RUNTIME = '1';
-process.env.JOVO_CLI_EXEC_PATH = dirname(__dirname);
 
 export { run } from '@oclif/command';
 export * from '@jovotech/cli-core';


### PR DESCRIPTION
## Proposed changes
Since #276 introduced imports directly from `@jovotech/cli`, the following statement in `index.ts` is called in locally installed instances as well:
```ts
process.env.JOVO_CLI_EXEC_PATH = dirname(__dirname);
```
which can cause issues when developing locally with the CLI. This PR fixes the issue by moving the statement to code that will only be executed when running the CLI, not when importing modules.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed