### PR TITLE
:ambulance: Fix boxen imports

### DIFF
--- a/jovo-cli/src/commands/run.ts
+++ b/jovo-cli/src/commands/run.ts
@@ -1,15 +1,15 @@
 import Command, { flags } from '@oclif/command';
-import * as boxen from 'boxen';
+import boxen, { BorderStyle as BoxenBorderStyle, Options as BoxenOptions } from 'boxen';
 import chalk from 'chalk';
-import spawn from 'cross-spawn';
-import * as JovoWebhookConnector from 'jovo-webhook-connector';
-import * as path from 'path';
-import open from 'open';
-import resolveBin from 'resolve-bin';
 import { ChildProcess } from 'child_process';
-import { accessSync, readFileSync } from 'fs-extra';
-import { getProject, InputFlags, JOVO_WEBHOOK_URL, JovoCliError } from 'jovo-cli-core';
+import spawn from 'cross-spawn';
+import { accessSync } from 'fs-extra';
+import { getProject, InputFlags, JovoCliError, JOVO_WEBHOOK_URL } from 'jovo-cli-core';
+import * as JovoWebhookConnector from 'jovo-webhook-connector';
 import _ from 'lodash';
+import open from 'open';
+import * as path from 'path';
+import resolveBin from 'resolve-bin';
 import {
   addBaseCliOptions,
   getPackageVersionsNpm,
@@ -108,14 +108,13 @@ export class Run extends Command {
 
         outputText.push('\nUse "jovo update" to get the newest versions.');
 
-        const boxOptions = {
+        const boxOptions: BoxenOptions = {
           padding: 1,
           margin: 1,
           borderColor: 'yellow',
-          borderStyle: 'round',
+          borderStyle: BoxenBorderStyle.Round,
         };
 
-        // @ts-ignore
         this.log(boxen(outputText.join('\n'), boxOptions));
         setUpdateMessageDisplayed();
       }


### PR DESCRIPTION
## Proposed changes
This PR fixes an issue with importing `boxen` when running `jovo3 run`.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed