### PR TITLE
:bug: Pass args to serverless exec Fixes #310

### DIFF
--- a/integrations/target-serverless/src/hooks/DeployHook.ts
+++ b/integrations/target-serverless/src/hooks/DeployHook.ts
@@ -65,7 +65,8 @@ export class DeployHook extends PluginHook<DeployCodeEvents> {
   async deployServerless(): Promise<void> {
     const deployTask: Task = new Task(`${ROCKET} Deploying to Serverless`, async () => {
       try {
-        await execAsync('serverless deploy', { cwd: this.$cli.projectPath });
+        const passingArguments = process.argv.slice(4).join(' ');
+        await execAsync('serverless deploy ' + passingArguments, { cwd: this.$cli.projectPath });
       } catch (error) {
         throw new JovoCliError({
           message: 'Serverless deployment failed.',


### PR DESCRIPTION
## Proposed changes
Fixes #310

Passes args to serverless exec

```sh
$ jovo deploy:code serverless --stage prod
```

`${opt:stage}` is `prod` 

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed