### PR TITLE
:label: updated type

### DIFF
--- a/core/src/interfaces.ts
+++ b/core/src/interfaces.ts
@@ -19,7 +19,7 @@ export type DefaultEvents = 'install';
 export type PluginType = 'platform' | 'target' | 'command' | '';
 
 export interface Files {
-  [key: string]: string | Files;
+  [key: string]: string | Files | Files[];
 }
 
 export interface LocaleMap {


### PR DESCRIPTION
## Proposed changes

`Type '{ name: PermissionName; }[]' is not assignable to type 'Files'.`

When trying to build my AlexaCliConfig in a TS file, TS won't let me assign arrays to properties, where arrays are needed, like `files['skill-package/skill.json'].manifes.permissions`. It can still be used though and works, if you just ignore the issue (like mostly done in .js project files).



## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed