### PR TITLE
🔨 Check for serverless args order

### DIFF
--- a/integrations/target-serverless/src/hooks/DeployHook.ts
+++ b/integrations/target-serverless/src/hooks/DeployHook.ts
@@ -16,9 +16,18 @@ export class DeployHook extends PluginHook<DeployCodeEvents> {
 
   install(): void {
     this.middlewareCollection = {
-      'before.deploy:code': [this.checkForTarget.bind(this), this.checkForServerlessCli.bind(this)],
+      'before.deploy:code': [this.checkForTarget.bind(this), this.checkForArgsOrder.bind(this), this.checkForServerlessCli.bind(this)],
       'deploy:code': [this.bundle.bind(this), this.deployServerless.bind(this)],
     };
+  }
+
+  checkForArgsOrder(): void {
+    if (process.argv[4] !== 'serverless') {
+      throw new JovoCliError({
+        module: 'ServerlessTarget',
+        message: 'Please put all flags after `serverless`. Remember they will be used from serverless deploy',
+      });
+    }
   }
 
   checkForTarget(): void {


### PR DESCRIPTION
## Proposed changes
Since arguments passed to `jovo deploy:code serverless {args}` are used only on an index-based logic (see code referenced in the issue), they need to be put after `serverless`.

The additional code checks the order of the arguments before running the deployment. When they are not in the right order, it raises an exception with an explicit and meaningful message about how to use the command in the right way.

Fixes https://github.com/jovotech/jovo-cli/issues/358

Note: there may be better error messages than the one I chose. Feel free to change it accordingly.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed